### PR TITLE
Feat : (Owner)선택 가게 주문내역 조회

### DIFF
--- a/src/main/java/com/example/burrrrng/controller/OwnerStoreController.java
+++ b/src/main/java/com/example/burrrrng/controller/OwnerStoreController.java
@@ -62,4 +62,12 @@ public class OwnerStoreController {
         return ownerStoreService.updateOrder(storeId, orderId, requestOrderUpdateDto, request);
     }
 
+    @GetMapping("/{storeId}/orders")
+    public CommonListResDto<ResponseViewOrderDto> viewStoreOrders(
+            @PathVariable Long storeId,
+            HttpServletRequest request
+    ){
+        return ownerStoreService.viewStoreOrders(storeId, request);
+    }
+
 }

--- a/src/main/java/com/example/burrrrng/controller/OwnerStoreController.java
+++ b/src/main/java/com/example/burrrrng/controller/OwnerStoreController.java
@@ -21,7 +21,7 @@ import java.util.List;
 public class OwnerStoreController {
 
     private final OwnerStoreService ownerStoreService;
-    private MenuService menuService;
+    private final MenuService menuService;
 
     @PostMapping
     public CommonResDto<ResponseOwnerStoreDto> createStore(@RequestBody RequestOwnerStoreDto requestOwnerStoreDto, HttpServletRequest request) {

--- a/src/main/java/com/example/burrrrng/dto/ResponseViewOrderDto.java
+++ b/src/main/java/com/example/burrrrng/dto/ResponseViewOrderDto.java
@@ -11,14 +11,16 @@ public class ResponseViewOrderDto implements ResDtoDataType {
     private OrderStatus orderStatus;
     private String address;
     private String mainMenu;
+    private int totalMenuCount;
 
     public ResponseViewOrderDto() {}
 
-    public ResponseViewOrderDto(Long id, OrderStatus orderStatus, String address, String mainMenu) {
+    public ResponseViewOrderDto(Long id, OrderStatus orderStatus, String address, String mainMenu, int totalMenuCount) {
         this.id = id;
         this.orderStatus = orderStatus;
         this.address = address;
         this.mainMenu = mainMenu;
+        this.totalMenuCount = totalMenuCount;
     }
 
 }

--- a/src/main/java/com/example/burrrrng/dto/ResponseViewOrderDto.java
+++ b/src/main/java/com/example/burrrrng/dto/ResponseViewOrderDto.java
@@ -1,0 +1,24 @@
+package com.example.burrrrng.dto;
+
+import com.example.burrrrng.dto.common.ResDtoDataType;
+import com.example.burrrrng.enums.OrderStatus;
+import lombok.Getter;
+
+@Getter
+public class ResponseViewOrderDto implements ResDtoDataType {
+
+    private Long id;
+    private OrderStatus orderStatus;
+    private String address;
+    private String mainMenu;
+
+    public ResponseViewOrderDto() {}
+
+    public ResponseViewOrderDto(Long id, OrderStatus orderStatus, String address, String mainMenu) {
+        this.id = id;
+        this.orderStatus = orderStatus;
+        this.address = address;
+        this.mainMenu = mainMenu;
+    }
+
+}

--- a/src/main/java/com/example/burrrrng/service/OwnerStoreService.java
+++ b/src/main/java/com/example/burrrrng/service/OwnerStoreService.java
@@ -229,7 +229,7 @@ public class OwnerStoreService {
         for (Order order : orders) {
             String mainMenu = "";
             double maxPrice = 0.0;
-
+            int totalMenuCount = order.getOrderMenus().size();
             for (OrderMenu orderMenu : order.getOrderMenus()) {
                 double menuPrice = orderMenu.getMenu().getPrice();
                 if (menuPrice > maxPrice) {
@@ -241,7 +241,8 @@ public class OwnerStoreService {
                     order.getId(),
                     order.getStatus(),
                     order.getUser().getAddress(),
-                    mainMenu
+                    mainMenu,
+                    totalMenuCount
             );
             orderDtos.add(dto);
         }

--- a/src/main/java/com/example/burrrrng/service/OwnerStoreService.java
+++ b/src/main/java/com/example/burrrrng/service/OwnerStoreService.java
@@ -5,10 +5,7 @@ import com.example.burrrrng.constants.Const;
 import com.example.burrrrng.dto.*;
 import com.example.burrrrng.dto.common.CommonListResDto;
 import com.example.burrrrng.dto.common.CommonResDto;
-import com.example.burrrrng.entity.Menu;
-import com.example.burrrrng.entity.Order;
-import com.example.burrrrng.entity.Store;
-import com.example.burrrrng.entity.User;
+import com.example.burrrrng.entity.*;
 import com.example.burrrrng.enums.StoreStatus;
 import com.example.burrrrng.enums.UserRole;
 import com.example.burrrrng.exception.StoreLimitException;
@@ -36,6 +33,7 @@ public class OwnerStoreService {
     private final UserRepository userRepository;
     private final MenuRepository menuRepository;
     private final OrderRepository orderRepository;
+
 
     public CommonResDto<ResponseOwnerStoreDto> createStore(RequestOwnerStoreDto requestOwnerStoreDto, HttpServletRequest request) {
         User user = (User) request.getSession().getAttribute(Const.LOGIN_USER);
@@ -211,4 +209,45 @@ public class OwnerStoreService {
 
         return new CommonResDto<>("해당 주문의 상태가 변경 되었습니다.", responseDto);
     }
+
+    public CommonListResDto<ResponseViewOrderDto> viewStoreOrders(Long id, HttpServletRequest request) {
+        User user = (User) request.getSession().getAttribute(Const.LOGIN_USER);
+
+        Store store = ownerStoreRepository.findByIdAndUserId(id, user.getId())
+                .orElseThrow(() -> new StoreNotFoundException("가게를 찾을 수 없습니다."));
+
+        if(store.getStatus() == StoreStatus.CLOSED){
+            throw new StoreNotFoundException("폐업된 가게입니다.");
+        }
+
+        List<Order> orders = store.getOrders();
+
+        orders.sort((o1, o2) -> o2.getUpdatedAt().compareTo(o1.getUpdatedAt()));
+
+        List<ResponseViewOrderDto> orderDtos = new ArrayList<>();
+
+        for (Order order : orders) {
+            String mainMenu = "";
+            double maxPrice = 0.0;
+
+            for (OrderMenu orderMenu : order.getOrderMenus()) {
+                double menuPrice = orderMenu.getMenu().getPrice();
+                if (menuPrice > maxPrice) {
+                    maxPrice = menuPrice;
+                    mainMenu = orderMenu.getMenu().getName();
+                }
+            }
+            ResponseViewOrderDto dto = new ResponseViewOrderDto(
+                    order.getId(),
+                    order.getStatus(),
+                    order.getUser().getAddress(),
+                    mainMenu
+            );
+            orderDtos.add(dto);
+        }
+
+        return new CommonListResDto<>("주문내역 조회 완료", orderDtos);
+
+    }
+
 }


### PR DESCRIPTION
GET  owner/stores/{storeId}/orders

선택된 가게로 들어온 주문 내역을 조회 하는 기능

개별 메뉴중 가격이 가장 비싼 메뉴를 mainMenu로 선정

List에 담긴 주문을  정렬을 통해 updatedAt을 비교하여 가장 최근에 업데이트 된 주문 내역부터 확인가능

Response : 
{
    "message": "주문내역 조회 완료",
    "data": [
        {
            "id": 1,
            "orderStatus": "cooking",
            "address": "address",
            "mainMenu": "menu2"
        },
        {
            "id": 2,
            "orderStatus": "unchecked",
            "address": "address",
            "mainMenu": "menu1"
        }
    ]
}